### PR TITLE
Feature: Search bar now uses levenshtein distance

### DIFF
--- a/open-students-front/package.json
+++ b/open-students-front/package.json
@@ -19,6 +19,7 @@
     "axios": "^1.6.7",
     "base64url": "^3.0.1",
     "dotenv": "^16.4.4",
+    "js-levenshtein": "^1.1.6",
     "mui": "^0.0.1",
     "react": "^18.2.0",
     "react-auth-kit": "^3.1.0",

--- a/open-students-front/src/utils/levenshtein.d.ts
+++ b/open-students-front/src/utils/levenshtein.d.ts
@@ -1,0 +1,4 @@
+// levenshtein.d.ts
+declare module "js-levenshtein" {
+  export default function (arg1: string, arg2: string): number;
+}

--- a/open-students-front/yarn.lock
+++ b/open-students-front/yarn.lock
@@ -1512,6 +1512,11 @@ js-cookie@^3.0.1:
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.5.tgz#0b7e2fd0c01552c58ba86e0841f94dc2557dcdbc"
   integrity sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==
 
+js-levenshtein@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
+  integrity sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
Search bar will now use a Normalized [Levenshtein Distance](https://en.wikipedia.org/wiki/Levenshtein_distance) for its results. It will also now Unicode normalize any names given by the API, adressing #3 as well.